### PR TITLE
[jhoon9494] 필터링, 검색 기능 구현

### DIFF
--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -6,6 +6,7 @@ export const getOrderData = async (
   date: string | null,
   sortType: string | null,
   status: string | null,
+  searchData: string | null,
 ) => {
   return await apiClient({
     method: 'get',
@@ -16,6 +17,7 @@ export const getOrderData = async (
       limit: ITEMS_PER_PAGE,
       sortType,
       status,
+      searchData,
     },
   });
 };

--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -1,7 +1,11 @@
 import { ITEMS_PER_PAGE } from '@/constants/units';
 import apiClient from './apiClient';
 
-export const getOrderData = async (offset: number, date: string | null) => {
+export const getOrderData = async (
+  offset: number,
+  date: string | null,
+  sortType?: string | null,
+) => {
   return await apiClient({
     method: 'get',
     url: '/mock/order',
@@ -9,6 +13,7 @@ export const getOrderData = async (offset: number, date: string | null) => {
       offset,
       date,
       limit: ITEMS_PER_PAGE,
+      sortType,
     },
   });
 };

--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -4,7 +4,8 @@ import apiClient from './apiClient';
 export const getOrderData = async (
   offset: number,
   date: string | null,
-  sortType?: string | null,
+  sortType: string | null,
+  status: string | null,
 ) => {
   return await apiClient({
     method: 'get',
@@ -14,6 +15,7 @@ export const getOrderData = async (
       date,
       limit: ITEMS_PER_PAGE,
       sortType,
+      status,
     },
   });
 };

--- a/src/components/OrderTableArea.tsx
+++ b/src/components/OrderTableArea.tsx
@@ -22,8 +22,8 @@ import TablePagination from './TablePagination';
 import TableController from './TableController';
 
 const OrderTableArea = () => {
-  const { currentPage, currentDate } = useSetParams();
-  const { data } = useGetOrderData(currentPage, currentDate);
+  const { currentPage, currentDate, sortType, setSortType } = useSetParams();
+  const { data } = useGetOrderData(currentPage, currentDate, sortType);
 
   return (
     <Box bg="white" w="100%" borderRadius="2xl" p="1em 2em">
@@ -45,10 +45,14 @@ const OrderTableArea = () => {
           </TableCaption>
           <Thead>
             <Tr>
-              <Th>Order ID</Th>
+              <Th onClick={() => setSortType('id')} cursor="pointer">
+                Order ID
+              </Th>
               <Th>Status</Th>
               <Th>Customer Name / ID</Th>
-              <Th>Time</Th>
+              <Th onClick={() => setSortType('time')} cursor="pointer">
+                Time
+              </Th>
               <Th>Currency</Th>
             </Tr>
           </Thead>

--- a/src/components/OrderTableArea.tsx
+++ b/src/components/OrderTableArea.tsx
@@ -22,8 +22,9 @@ import TablePagination from './TablePagination';
 import TableController from './TableController';
 
 const OrderTableArea = () => {
-  const { currentPage, currentDate, sortType, setSortType } = useSetParams();
-  const { data } = useGetOrderData(currentPage, currentDate, sortType);
+  const { currentPage, currentDate, sortType, setSortType, setStatus, status } =
+    useSetParams();
+  const { data } = useGetOrderData(currentPage, currentDate, sortType, status);
 
   return (
     <Box bg="white" w="100%" borderRadius="2xl" p="1em 2em">
@@ -48,7 +49,9 @@ const OrderTableArea = () => {
               <Th onClick={() => setSortType('id')} cursor="pointer">
                 Order ID
               </Th>
-              <Th>Status</Th>
+              <Th onClick={() => setStatus('true')} cursor="pointer">
+                Status
+              </Th>
               <Th>Customer Name / ID</Th>
               <Th onClick={() => setSortType('time')} cursor="pointer">
                 Time

--- a/src/components/OrderTableArea.tsx
+++ b/src/components/OrderTableArea.tsx
@@ -12,19 +12,30 @@ import {
   Spacer,
   Flex,
   Heading,
+  Input,
+  Button,
+  HStack,
 } from '@chakra-ui/react';
 import { CheckIcon, WarningIcon } from '@chakra-ui/icons';
 import { IOrderItem } from '@/interface/main';
 import useSetParams from '@/lib/hooks/useSetParams';
 import { formatPageInfo } from '@/lib/utils/formattingHelper';
 import useGetOrderData from '@/lib/hooks/useGetOrderData';
+import useSearch from '@/lib/hooks/useSearch';
 import TablePagination from './TablePagination';
 import TableController from './TableController';
 
 const OrderTableArea = () => {
   const { currentPage, currentDate, sortType, setSortType, setStatus, status } =
     useSetParams();
-  const { data } = useGetOrderData(currentPage, currentDate, sortType, status);
+  const { onSearch, searchData, formRef, inputRef, onReset } = useSearch();
+  const { data } = useGetOrderData(
+    currentPage,
+    currentDate,
+    sortType,
+    status,
+    searchData,
+  );
 
   return (
     <Box bg="white" w="100%" borderRadius="2xl" p="1em 2em">
@@ -32,6 +43,28 @@ const OrderTableArea = () => {
         <Box p="2">
           <Heading size="md">주문 테이블</Heading>
         </Box>
+        <Box flex={4}>
+          <form onSubmit={onSearch} ref={formRef}>
+            <HStack>
+              <Input
+                placeholder="고객 이름을 입력해주세요."
+                size="sm"
+                ref={inputRef}
+              />
+              <Button type="submit" size="sm">
+                검색
+              </Button>
+            </HStack>
+          </form>
+        </Box>
+        <Button
+          type="button"
+          size="sm"
+          onClick={onReset}
+          isDisabled={!searchData}
+        >
+          reset
+        </Button>
         <Spacer />
         <TableController />
       </Flex>

--- a/src/components/OrderTableArea.tsx
+++ b/src/components/OrderTableArea.tsx
@@ -17,25 +17,16 @@ import {
   HStack,
 } from '@chakra-ui/react';
 import { CheckIcon, WarningIcon } from '@chakra-ui/icons';
-import { IOrderItem } from '@/interface/main';
+import { IFetchData, IOrderItem } from '@/interface/main';
 import useSetParams from '@/lib/hooks/useSetParams';
 import { formatPageInfo } from '@/lib/utils/formattingHelper';
-import useGetOrderData from '@/lib/hooks/useGetOrderData';
 import useSearch from '@/lib/hooks/useSearch';
 import TablePagination from './TablePagination';
 import TableController from './TableController';
 
-const OrderTableArea = () => {
-  const { currentPage, currentDate, sortType, setSortType, setStatus, status } =
-    useSetParams();
+const OrderTableArea = ({ data }: { data: IFetchData | undefined }) => {
+  const { currentPage, setSortType, setStatus } = useSetParams();
   const { onSearch, searchData, formRef, inputRef, onReset } = useSearch();
-  const { data } = useGetOrderData(
-    currentPage,
-    currentDate,
-    sortType,
-    status,
-    searchData,
-  );
 
   return (
     <Box bg="white" w="100%" borderRadius="2xl" p="1em 2em">
@@ -73,8 +64,8 @@ const OrderTableArea = () => {
           <TableCaption>
             {formatPageInfo(
               currentPage,
-              data.order.length,
-              data.orderInfo.totalCount,
+              data?.order.length,
+              data?.orderInfo.totalCount,
             )}
           </TableCaption>
           <Thead>
@@ -93,7 +84,7 @@ const OrderTableArea = () => {
             </Tr>
           </Thead>
           <Tbody>
-            {data.order.map((orderItem: IOrderItem) => {
+            {data?.order.map((orderItem: IOrderItem) => {
               return (
                 <Tr key={orderItem.id}>
                   <Td>{orderItem.id}</Td>
@@ -121,7 +112,7 @@ const OrderTableArea = () => {
           </Tbody>
         </Table>
       </TableContainer>
-      <TablePagination />
+      <TablePagination totalCount={data?.orderInfo.totalCount} />
     </Box>
   );
 };

--- a/src/components/OrderTableArea.tsx
+++ b/src/components/OrderTableArea.tsx
@@ -35,27 +35,30 @@ const OrderTableArea = ({ data }: { data: IFetchData | undefined }) => {
           <Heading size="md">주문 테이블</Heading>
         </Box>
         <Box flex={4}>
-          <form onSubmit={onSearch} ref={formRef}>
-            <HStack>
-              <Input
-                placeholder="고객 이름을 입력해주세요."
-                size="sm"
-                ref={inputRef}
-              />
-              <Button type="submit" size="sm">
-                검색
-              </Button>
-            </HStack>
-          </form>
+          <HStack maxW="500px">
+            <form onSubmit={onSearch} ref={formRef} style={{ flex: 1 }}>
+              <HStack>
+                <Input
+                  placeholder="고객 이름을 입력해주세요."
+                  size="sm"
+                  ref={inputRef}
+                />
+                <Button type="submit" size="sm">
+                  검색
+                </Button>
+              </HStack>
+            </form>
+            <Button
+              type="button"
+              size="sm"
+              onClick={onReset}
+              isDisabled={!searchData}
+            >
+              reset
+            </Button>
+          </HStack>
         </Box>
-        <Button
-          type="button"
-          size="sm"
-          onClick={onReset}
-          isDisabled={!searchData}
-        >
-          reset
-        </Button>
+
         <Spacer />
         <TableController />
       </Flex>

--- a/src/components/StatsArea.tsx
+++ b/src/components/StatsArea.tsx
@@ -18,8 +18,8 @@ import useGetOrderData from '@/lib/hooks/useGetOrderData';
 import useSetParams from '@/lib/hooks/useSetParams';
 
 const StatsArea = () => {
-  const { currentPage, currentDate, sortType } = useSetParams();
-  const { data } = useGetOrderData(currentPage, currentDate, sortType);
+  const { currentPage, currentDate, sortType, status } = useSetParams();
+  const { data } = useGetOrderData(currentPage, currentDate, sortType, status);
 
   const stats = [
     {

--- a/src/components/StatsArea.tsx
+++ b/src/components/StatsArea.tsx
@@ -16,10 +16,18 @@ import { formatNumToDollar } from '@/lib/utils/formattingHelper';
 import { IOrderItem } from '@/interface/main';
 import useGetOrderData from '@/lib/hooks/useGetOrderData';
 import useSetParams from '@/lib/hooks/useSetParams';
+import useSearch from '@/lib/hooks/useSearch';
 
 const StatsArea = () => {
+  const { searchData } = useSearch();
   const { currentPage, currentDate, sortType, status } = useSetParams();
-  const { data } = useGetOrderData(currentPage, currentDate, sortType, status);
+  const { data } = useGetOrderData(
+    currentPage,
+    currentDate,
+    sortType,
+    status,
+    searchData,
+  );
 
   const stats = [
     {

--- a/src/components/StatsArea.tsx
+++ b/src/components/StatsArea.tsx
@@ -18,8 +18,8 @@ import useGetOrderData from '@/lib/hooks/useGetOrderData';
 import useSetParams from '@/lib/hooks/useSetParams';
 
 const StatsArea = () => {
-  const { currentPage, currentDate } = useSetParams();
-  const { data } = useGetOrderData(currentPage, currentDate);
+  const { currentPage, currentDate, sortType } = useSetParams();
+  const { data } = useGetOrderData(currentPage, currentDate, sortType);
 
   const stats = [
     {

--- a/src/components/StatsArea.tsx
+++ b/src/components/StatsArea.tsx
@@ -13,47 +13,34 @@ import { CheckIcon, WarningIcon } from '@chakra-ui/icons';
 import { IoIosPeople } from 'react-icons/io';
 import { TfiMoney } from 'react-icons/tfi';
 import { formatNumToDollar } from '@/lib/utils/formattingHelper';
-import { IOrderItem } from '@/interface/main';
-import useGetOrderData from '@/lib/hooks/useGetOrderData';
-import useSetParams from '@/lib/hooks/useSetParams';
-import useSearch from '@/lib/hooks/useSearch';
+import { IFetchData, IOrderItem } from '@/interface/main';
 
-const StatsArea = () => {
-  const { searchData } = useSearch();
-  const { currentPage, currentDate, sortType, status } = useSetParams();
-  const { data } = useGetOrderData(
-    currentPage,
-    currentDate,
-    sortType,
-    status,
-    searchData,
-  );
-
+const StatsArea = ({ data }: { data: IFetchData | undefined }) => {
   const stats = [
     {
       label: 'Total Order',
-      stat: data.orderInfo.totalCount,
+      stat: data?.orderInfo.totalCount,
       icon: IoIosPeople,
       iconColor: 'blue.900',
-      helpText: `${data.orderInfo.startDate} - ${data.orderInfo.endDate}`,
+      helpText: `${data?.orderInfo.startDate} - ${data?.orderInfo.endDate}`,
     },
     {
       label: 'Total Currency',
-      stat: formatNumToDollar(data.orderInfo.totalCurrency),
+      stat: formatNumToDollar(data?.orderInfo.totalCurrency),
       icon: TfiMoney,
       iconColor: 'blue.900',
-      helpText: `${data.orderInfo.startDate} - ${data.orderInfo.endDate}`,
+      helpText: `${data?.orderInfo.startDate} - ${data?.orderInfo.endDate}`,
     },
     {
       label: 'Complete',
-      stat: data.order.filter((item: IOrderItem) => item.status).length,
+      stat: data?.order.filter((item: IOrderItem) => item.status).length,
       icon: CheckIcon,
       iconColor: 'green.500',
       helpText: 'per Page',
     },
     {
       label: 'Incomplete',
-      stat: data.order.filter((item: IOrderItem) => !item.status).length,
+      stat: data?.order.filter((item: IOrderItem) => !item.status).length,
       icon: WarningIcon,
       iconColor: 'orange.500',
       helpText: 'per Page',

--- a/src/components/TableController.tsx
+++ b/src/components/TableController.tsx
@@ -3,10 +3,13 @@ import useSetParams from '@/lib/hooks/useSetParams';
 import { TODAY } from '@/constants/config';
 
 const TableController = () => {
-  const { onSetParams } = useSetParams();
+  const { onSetParams, setStatus } = useSetParams();
 
   return (
     <ButtonGroup variant="outline" spacing="4">
+      <Button colorScheme="blue" size="sm" onClick={() => setStatus('')}>
+        필터링 취소
+      </Button>
       <Button
         colorScheme="blue"
         size="sm"

--- a/src/components/TablePagination.tsx
+++ b/src/components/TablePagination.tsx
@@ -3,11 +3,19 @@ import useSetParams from '@/lib/hooks/useSetParams';
 import { ITEMS_PER_PAGE } from '@/constants/units';
 import { generateZeroToNArr } from '@/lib/utils/generator';
 import useGetOrderData from '@/lib/hooks/useGetOrderData';
+import useSearch from '@/lib/hooks/useSearch';
 
 const TablePagination = () => {
+  const { searchData } = useSearch();
   const { currentPage, currentDate, onSetParams, sortType, status } =
     useSetParams();
-  const { data } = useGetOrderData(currentPage, currentDate, sortType, status);
+  const { data } = useGetOrderData(
+    currentPage,
+    currentDate,
+    sortType,
+    status,
+    searchData,
+  );
 
   return (
     <Stack spacing={2} direction="row" align="center">

--- a/src/components/TablePagination.tsx
+++ b/src/components/TablePagination.tsx
@@ -8,7 +8,7 @@ const TablePagination = ({
 }: {
   totalCount: number | undefined;
 }) => {
-  const { currentPage, onSetParams } = useSetParams();
+  const { currentPage, onSetParams, currentDate } = useSetParams();
 
   return (
     <Stack spacing={2} direction="row" align="center">
@@ -18,7 +18,12 @@ const TablePagination = ({
           colorScheme="blue"
           size="sm"
           key={num}
-          onClick={() => onSetParams({ pageValue: num + 1 })}
+          onClick={() =>
+            onSetParams({
+              pageValue: num + 1,
+              dateValue: currentDate ? currentDate : '',
+            })
+          }
           variant={currentPage === num + 1 ? 'solid' : 'outline'}
         >
           {num + 1}

--- a/src/components/TablePagination.tsx
+++ b/src/components/TablePagination.tsx
@@ -5,8 +5,9 @@ import { generateZeroToNArr } from '@/lib/utils/generator';
 import useGetOrderData from '@/lib/hooks/useGetOrderData';
 
 const TablePagination = () => {
-  const { currentPage, currentDate, onSetParams, sortType } = useSetParams();
-  const { data } = useGetOrderData(currentPage, currentDate, sortType);
+  const { currentPage, currentDate, onSetParams, sortType, status } =
+    useSetParams();
+  const { data } = useGetOrderData(currentPage, currentDate, sortType, status);
 
   return (
     <Stack spacing={2} direction="row" align="center">

--- a/src/components/TablePagination.tsx
+++ b/src/components/TablePagination.tsx
@@ -2,26 +2,17 @@ import { Button, Stack } from '@chakra-ui/react';
 import useSetParams from '@/lib/hooks/useSetParams';
 import { ITEMS_PER_PAGE } from '@/constants/units';
 import { generateZeroToNArr } from '@/lib/utils/generator';
-import useGetOrderData from '@/lib/hooks/useGetOrderData';
-import useSearch from '@/lib/hooks/useSearch';
 
-const TablePagination = () => {
-  const { searchData } = useSearch();
-  const { currentPage, currentDate, onSetParams, sortType, status } =
-    useSetParams();
-  const { data } = useGetOrderData(
-    currentPage,
-    currentDate,
-    sortType,
-    status,
-    searchData,
-  );
+const TablePagination = ({
+  totalCount = 0,
+}: {
+  totalCount: number | undefined;
+}) => {
+  const { currentPage, onSetParams } = useSetParams();
 
   return (
     <Stack spacing={2} direction="row" align="center">
-      {generateZeroToNArr(
-        Math.ceil(data.orderInfo.totalCount / ITEMS_PER_PAGE),
-      ).map((num) => (
+      {generateZeroToNArr(Math.ceil(totalCount / ITEMS_PER_PAGE)).map((num) => (
         <Button
           type="button"
           colorScheme="blue"

--- a/src/components/TablePagination.tsx
+++ b/src/components/TablePagination.tsx
@@ -5,8 +5,8 @@ import { generateZeroToNArr } from '@/lib/utils/generator';
 import useGetOrderData from '@/lib/hooks/useGetOrderData';
 
 const TablePagination = () => {
-  const { currentPage, currentDate, onSetParams } = useSetParams();
-  const { data } = useGetOrderData(currentPage, currentDate);
+  const { currentPage, currentDate, onSetParams, sortType } = useSetParams();
+  const { data } = useGetOrderData(currentPage, currentDate, sortType);
 
   return (
     <Stack spacing={2} direction="row" align="center">

--- a/src/interface/main.d.ts
+++ b/src/interface/main.d.ts
@@ -23,3 +23,8 @@ export interface IOnSetParams {
 export interface IErrorFallbackProps {
   resetErrorBoundary: (...args: unknown[]) => void;
 }
+
+export interface IFetchData {
+  order: IOrderItem[];
+  orderInfo: IOrderInfo;
+}

--- a/src/lib/hooks/useGetOrderData.ts
+++ b/src/lib/hooks/useGetOrderData.ts
@@ -6,11 +6,14 @@ const useGetOrderData = (
   date: string | null,
   sortType: string | null,
   status: string | null,
+  searchData: string | null,
 ) => {
   return useQuery({
-    queryKey: ['/mock/order', pageNum, date, sortType, status],
+    queryKey: ['/mock/order', pageNum, date, sortType, status, searchData],
     queryFn: () =>
-      getOrderData(pageNum - 1, date, sortType, status).then((res) => res.data),
+      getOrderData(pageNum - 1, date, sortType, status, searchData).then(
+        (res) => res.data,
+      ),
     refetchInterval: 5000,
   });
 };

--- a/src/lib/hooks/useGetOrderData.ts
+++ b/src/lib/hooks/useGetOrderData.ts
@@ -4,12 +4,13 @@ import { getOrderData } from '@/api/order';
 const useGetOrderData = (
   pageNum = 1,
   date: string | null,
-  sortType?: string | null,
+  sortType: string | null,
+  status: string | null,
 ) => {
   return useQuery({
-    queryKey: ['/mock/order', pageNum, date, sortType],
+    queryKey: ['/mock/order', pageNum, date, sortType, status],
     queryFn: () =>
-      getOrderData(pageNum - 1, date, sortType).then((res) => res.data),
+      getOrderData(pageNum - 1, date, sortType, status).then((res) => res.data),
     refetchInterval: 5000,
   });
 };

--- a/src/lib/hooks/useGetOrderData.ts
+++ b/src/lib/hooks/useGetOrderData.ts
@@ -1,10 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { getOrderData } from '@/api/order';
 
-const useGetOrderData = (pageNum = 1, date: string | null) => {
+const useGetOrderData = (
+  pageNum = 1,
+  date: string | null,
+  sortType?: string | null,
+) => {
   return useQuery({
-    queryKey: ['/mock/order', pageNum, date],
-    queryFn: () => getOrderData(pageNum - 1, date).then((res) => res.data),
+    queryKey: ['/mock/order', pageNum, date, sortType],
+    queryFn: () =>
+      getOrderData(pageNum - 1, date, sortType).then((res) => res.data),
     refetchInterval: 5000,
   });
 };

--- a/src/lib/hooks/useGetOrderData.ts
+++ b/src/lib/hooks/useGetOrderData.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { getOrderData } from '@/api/order';
+import { IFetchData } from '@/interface/main';
 
 const useGetOrderData = (
   pageNum = 1,
@@ -8,7 +9,7 @@ const useGetOrderData = (
   status: string | null,
   searchData: string | null,
 ) => {
-  return useQuery({
+  return useQuery<IFetchData>({
     queryKey: ['/mock/order', pageNum, date, sortType, status, searchData],
     queryFn: () =>
       getOrderData(pageNum - 1, date, sortType, status, searchData).then(

--- a/src/lib/hooks/useSearch.ts
+++ b/src/lib/hooks/useSearch.ts
@@ -1,0 +1,28 @@
+import { FormEvent, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const useSearch = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const formRef = useRef<HTMLFormElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const searchData = searchParams.get('search');
+
+  const onSearch = (e: FormEvent) => {
+    e.preventDefault();
+
+    const value = inputRef.current?.value || '';
+    searchParams.set('search', value);
+    setSearchParams(searchParams);
+
+    formRef.current?.reset();
+  };
+
+  const onReset = () => {
+    searchParams.delete('search');
+    setSearchParams(searchParams);
+  };
+
+  return { onSearch, searchData, formRef, inputRef, onReset };
+};
+
+export default useSearch;

--- a/src/lib/hooks/useSetParams.ts
+++ b/src/lib/hooks/useSetParams.ts
@@ -17,7 +17,15 @@ const useSetParams = () => {
     window.scrollTo(0, 0);
   };
 
-  return { currentPage, currentDate, onSetParams };
+  const sortType = searchParams.get('sort') || 'id';
+
+  const setSortType = (type: string) => {
+    if (sortType === type) searchParams.set('sort', `reverse-${type}`);
+    else searchParams.set('sort', type);
+    setSearchParams(searchParams);
+  };
+
+  return { currentPage, currentDate, onSetParams, sortType, setSortType };
 };
 
 export default useSetParams;

--- a/src/lib/hooks/useSetParams.ts
+++ b/src/lib/hooks/useSetParams.ts
@@ -18,14 +18,32 @@ const useSetParams = () => {
   };
 
   const sortType = searchParams.get('sort') || 'id';
-
   const setSortType = (type: string) => {
     if (sortType === type) searchParams.set('sort', `reverse-${type}`);
     else searchParams.set('sort', type);
     setSearchParams(searchParams);
   };
 
-  return { currentPage, currentDate, onSetParams, sortType, setSortType };
+  const status = searchParams.get('status');
+  const setStatus = (value: string) => {
+    if (!value) searchParams.delete('status');
+    else {
+      if (status === value) searchParams.set('status', 'false');
+      else searchParams.set('status', 'true');
+    }
+    searchParams.set('page', '1');
+    setSearchParams(searchParams);
+  };
+
+  return {
+    currentPage,
+    currentDate,
+    onSetParams,
+    sortType,
+    setSortType,
+    status,
+    setStatus,
+  };
 };
 
 export default useSetParams;

--- a/src/lib/hooks/useSetParams.ts
+++ b/src/lib/hooks/useSetParams.ts
@@ -9,6 +9,8 @@ const useSetParams = () => {
   const onSetParams = ({ pageValue, dateValue, event }: IOnSetParams) => {
     if (pageValue !== undefined) searchParams.set('page', String(pageValue));
     if (dateValue !== undefined) searchParams.set('date', String(dateValue));
+    if (!dateValue) searchParams.delete('date');
+
     if (event) searchParams.set('date', String(event.target.value));
 
     setSearchParams(searchParams);

--- a/src/lib/utils/formattingHelper.ts
+++ b/src/lib/utils/formattingHelper.ts
@@ -2,7 +2,7 @@ import { ITEMS_PER_PAGE } from '@/constants/units';
 
 export const formatDollarToNumber = (str: string) => Number(str.split('$')[1]);
 
-export const formatNumToDollar = (num: number) =>
+export const formatNumToDollar = (num: number | undefined = 0) =>
   `$ ${num.toLocaleString('en')}`;
 
 export const formatDate = (date: Date) =>
@@ -10,8 +10,8 @@ export const formatDate = (date: Date) =>
 
 export const formatPageInfo = (
   currentPage: number,
-  currentLength: number,
-  totalLength: number,
+  currentLength: number | undefined = 0,
+  totalLength: number | undefined = 0,
 ) =>
   `Showing ${currentPage * ITEMS_PER_PAGE - (ITEMS_PER_PAGE - 1)} - ${
     currentPage * ITEMS_PER_PAGE - ITEMS_PER_PAGE + currentLength

--- a/src/lib/utils/generator.ts
+++ b/src/lib/utils/generator.ts
@@ -3,6 +3,7 @@ import { formatDate } from './formattingHelper';
 
 const maxDate = (dates: Date[]) => new Date(Math.max(...dates.map(Number)));
 const minDate = (dates: Date[]) => new Date(Math.min(...dates.map(Number)));
+const DateToNum = (date: string) => Number(new Date(date));
 
 export const generateStartAndEndDate = (data: IOrderItem[]) => {
   const dateList = data.map(
@@ -16,3 +17,24 @@ export const generateStartAndEndDate = (data: IOrderItem[]) => {
 };
 
 export const generateZeroToNArr = (n: number) => Array.from(Array(n).keys());
+
+export const generateSortedList = (
+  array: IOrderItem[],
+  sortType: string | null,
+) => {
+  return [...array].sort((a, b) => {
+    if (sortType === 'id') {
+      return a.id - b.id;
+    }
+    if (sortType === 'reverse-id') {
+      return b.id - a.id;
+    }
+    if (sortType === 'time') {
+      return DateToNum(b.transaction_time) - DateToNum(a.transaction_time);
+    }
+    if (sortType === 'reverse-time') {
+      return DateToNum(a.transaction_time) - DateToNum(b.transaction_time);
+    }
+    return a.id - b.id;
+  });
+};

--- a/src/mocks/handlers/order.ts
+++ b/src/mocks/handlers/order.ts
@@ -1,6 +1,9 @@
 import { rest } from 'msw';
 import { formatDollarToNumber } from '@/lib/utils/formattingHelper';
-import { generateStartAndEndDate } from '@/lib/utils/generator';
+import {
+  generateSortedList,
+  generateStartAndEndDate,
+} from '@/lib/utils/generator';
 import mockData from '../storage/mock_data.json';
 
 export const orderListHandlers = [
@@ -8,16 +11,19 @@ export const orderListHandlers = [
     const offset = Number(req.url.searchParams.get('offset'));
     const limit = Number(req.url.searchParams.get('limit'));
     const date = req.url.searchParams.get('date');
+    const sortType = req.url.searchParams.get('sortType');
 
     const dataOfSelectedDate = date
       ? mockData.filter((item) => item.transaction_time.split(' ')[0] === date)
       : mockData;
 
+    const sortedData = generateSortedList(dataOfSelectedDate, sortType);
+
     const { startDate, endDate } = generateStartAndEndDate(dataOfSelectedDate);
 
     return res(
       ctx.json({
-        order: [...dataOfSelectedDate].splice(offset * limit, limit),
+        order: [...sortedData].splice(offset * limit, limit),
         orderInfo: {
           totalCount: dataOfSelectedDate.length,
           totalCurrency: dataOfSelectedDate.reduce(

--- a/src/mocks/handlers/order.ts
+++ b/src/mocks/handlers/order.ts
@@ -13,15 +13,19 @@ export const orderListHandlers = [
     const date = req.url.searchParams.get('date');
     const sortType = req.url.searchParams.get('sortType');
     const status = req.url.searchParams.get('status');
+    const searchData = req.url.searchParams.get('searchData');
 
     const dataOfSelectedDate = date
       ? mockData.filter((item) => item.transaction_time.split(' ')[0] === date)
       : mockData;
 
-    const dataOfSortedByTimeOrId = generateSortedList(
-      dataOfSelectedDate,
-      sortType,
-    );
+    const dataOfSearch = searchData
+      ? dataOfSelectedDate.filter((item) =>
+          item.customer_name.toUpperCase().includes(searchData.toUpperCase()),
+        )
+      : dataOfSelectedDate;
+
+    const dataOfSortedByTimeOrId = generateSortedList(dataOfSearch, sortType);
 
     const dataOfFilteredByStatus = status
       ? [...dataOfSortedByTimeOrId].filter(

--- a/src/mocks/handlers/order.ts
+++ b/src/mocks/handlers/order.ts
@@ -12,21 +12,31 @@ export const orderListHandlers = [
     const limit = Number(req.url.searchParams.get('limit'));
     const date = req.url.searchParams.get('date');
     const sortType = req.url.searchParams.get('sortType');
+    const status = req.url.searchParams.get('status');
 
     const dataOfSelectedDate = date
       ? mockData.filter((item) => item.transaction_time.split(' ')[0] === date)
       : mockData;
 
-    const sortedData = generateSortedList(dataOfSelectedDate, sortType);
+    const dataOfSortedByTimeOrId = generateSortedList(
+      dataOfSelectedDate,
+      sortType,
+    );
+
+    const dataOfFilteredByStatus = status
+      ? [...dataOfSortedByTimeOrId].filter(
+          (item) => String(item.status) === status,
+        )
+      : dataOfSortedByTimeOrId;
 
     const { startDate, endDate } = generateStartAndEndDate(dataOfSelectedDate);
 
     return res(
       ctx.json({
-        order: [...sortedData].splice(offset * limit, limit),
+        order: [...dataOfFilteredByStatus].splice(offset * limit, limit),
         orderInfo: {
-          totalCount: dataOfSelectedDate.length,
-          totalCurrency: dataOfSelectedDate.reduce(
+          totalCount: dataOfFilteredByStatus.length,
+          totalCurrency: dataOfFilteredByStatus.reduce(
             (acc, cur) => acc + formatDollarToNumber(cur.currency),
             0,
           ),

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,13 +1,25 @@
 import StatsArea from '@/components/StatsArea';
 import OrderTableArea from '@/components/OrderTableArea';
 import DatePicker from '@/components/DatePicker';
+import useSetParams from '@/lib/hooks/useSetParams';
+import useGetOrderData from '@/lib/hooks/useGetOrderData';
+import useSearch from '@/lib/hooks/useSearch';
 
 const AdminPage = () => {
+  const { currentPage, currentDate, sortType, status } = useSetParams();
+  const { searchData } = useSearch();
+  const { data } = useGetOrderData(
+    currentPage,
+    currentDate,
+    sortType,
+    status,
+    searchData,
+  );
   return (
     <>
-      <StatsArea />
+      <StatsArea data={data} />
       <DatePicker />
-      <OrderTableArea />
+      <OrderTableArea data={data} />
     </>
   );
 };


### PR DESCRIPTION
## 구현 기능
- [x] 기본 정렬은 ID 기준 오름차순으로 구현해주세요
- [x] 표에서 주문번호, 거래일 & 거래시간 버튼을 누르면 각각 내림차순 정렬이 되도록 해주세요
- [x] 주문 처리 상태에 따라 filtering 기능을 구현해주세요
- [x] 고객이름을 검색할 수 있도록 해주세요

## 참고 사항
시간이 빠듯하여 디자인보다는 기능 구현에 집중했습니다..!

### 정렬
전체 데이터를 기준으로 정렬하였습니다.
해당 페이지를 사용하는 입장에서 전체 목록 중 가장 최근에 주문된 Id나 최근 거래된 날짜를 확인하는 경우가 많다고 생각하기 때문입니다. 
주문 번호는 고유한 값이므로 공통되는 부분이 없기 때문에 거래 시간과 중첩하여 정렬하지 않았습니다.

### query string
- 주문 번호 정렬 : `sort=id` `sort=reverse-id`
- 거래 시간 정렬 : `sort=time` `sort=reverse-time`
- 주문 처리 상태 : `status=true` `status=false` 
- 고객 이름 검색 : `search=<username>`

표에서 각 항목의 제목인 orderID, status, time을 클릭할 경우 정렬 및 필터링이 적용됩니다.
input 창에 검색어를 입력하고 검색하면 해당 검색어가 포함된 이름을 가진 유저를 불러옵니다.
검색 버튼 옆의 reset 버튼을 클릭하여 주문 목록을 초기화 할 수 있습니다.

주로 어떤 resource를 식별할 때 path variable을 사용하고, 정렬이나 필터링을 한다면 query string을 사용하는 것이 이상적이라고 합니다.
주문 번호의 경우 고유한 값을 가지므로 식별할 수 있지만, 유저의 이름은 중복될 수 있기 때문에 query string으로 구현하였습니다.

### 커스텀 훅
유저 검색의 경우 입력이 필요하여 useSearch라는 커스텀 훅을 생성하여 입력을 받고 querystring으로 전달하였습니다.
정렬, 필터링은 useSetParams 커스텀 훅에 기능을 추가하여 동작하도록 구현하였습니다.

### useGetOrderData
useGetOrderData로 전달되는 파라미터 값이 다를 경우 data fetch가 여러번 발생하는 문제가 있었습니다.
data를 fetch하는 useGetOrderData 훅을 여러 컴포넌트에서 중복하여 사용할 필요가 없다고 생각되어 AdminPage 컴포넌트에서 실행 후 props로 fetch data를 전달하였습니다.

## SAMPLE
### 주문 번호 정렬
![주문 번호 정렬](https://user-images.githubusercontent.com/82688516/226570598-a4de1f09-2d18-4588-8717-362e3c77afaa.gif)

### 거래 시간 정렬
![거래 시간 정렬](https://user-images.githubusercontent.com/82688516/226570219-b5b1f1c6-302a-4d39-a608-112b6fc2b1ea.gif)

### 주문 상태 필터링
![주문상태 필터링](https://user-images.githubusercontent.com/82688516/226570233-d71128fb-f0da-4e8e-a68d-9c857ba70600.gif)

### 유저 검색
![유저 검색](https://user-images.githubusercontent.com/82688516/226570840-b7331849-b19b-4192-b5bd-0457ec14c7f9.gif)
