### PR TITLE
fix: orderResult 빈값 참조 에러 예외 처리

### DIFF
--- a/src/components/OrderTableArea.tsx
+++ b/src/components/OrderTableArea.tsx
@@ -31,6 +31,8 @@ const OrderTableArea = () => {
     getParams('sort'),
   );
 
+  if (!orderResult) return <></>;
+
   return (
     <Box bg="white" w="100%" borderRadius="md" boxShadow="lg">
       <Box p="1em 2em">

--- a/src/components/StatsArea.tsx
+++ b/src/components/StatsArea.tsx
@@ -28,6 +28,8 @@ const StatsArea = () => {
     getParams('sort'),
   );
 
+  if (!orderResult) return <></>;
+
   const stats = [
     {
       label: 'Total Order',
@@ -85,7 +87,11 @@ const StatsArea = () => {
                 />
               </Center>
               <Stat>
-                <StatLabel>{stat.label}</StatLabel>
+                <StatLabel
+                  onClick={(e) => console.log(e.nativeEvent.currentTarget)}
+                >
+                  {stat.label}
+                </StatLabel>
                 <StatNumber>{stat.stat}</StatNumber>
                 <StatHelpText>{stat.helpText}</StatHelpText>
               </Stat>


### PR DESCRIPTION
## 구현 기능
`OrderTableArea` 및 `StatsArea` 컴포넌트에서 발생하는 `빈값의 프로퍼티를 참조`하는 문제를 해결하기위해 아래와 같이 예외처리

![image](https://github.com/Wanted-PreOnboarding-Team-8/pre-onboarding-9th-4-8/assets/17325845/23adf2d2-7194-4813-9c59-1b1538cd9298)


## 참고 사항
- `orderResult`값을 참조하는 곳마다 옵셔널 체이닝을 추가하는걸 생각했지만 확장될수록 더 고려해야할것이 늘어나기때문에 조건부 렌더링을 통해 값이 없다면 빈 프레그먼트만 리턴하도록 하였습니다.

 